### PR TITLE
Add the others section explicitly in the yaml file

### DIFF
--- a/static/data/index.yaml
+++ b/static/data/index.yaml
@@ -14,5 +14,6 @@ sets:
     - null
   QUEST#5:
     - null
+others:
 reviews:
   - 10.1021/acs.jpclett.0c00014


### PR DESCRIPTION
Add the `others `section explicitly in the yaml file for a better understanding of how to add a publication to the `Other publications using QUEST` section.